### PR TITLE
Added second level directorys in side includes to the manifest.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include README.rst
 include include/*
 include include_*/*
+include include_*/*/*
 include licenses/*
 include src_nt/*


### PR DESCRIPTION
Fixes bug where the include_uuid/uuid/\* headers are not included in the packaging preventing builds on linux machines through pip.
